### PR TITLE
drop all GIR files and gdk-pixbuf tests after compilation

### DIFF
--- a/org.gnome.Papers.json
+++ b/org.gnome.Papers.json
@@ -34,6 +34,7 @@
         "/man",
         "/share/man",
         "/share/gtk-doc",
+        "/share/gir-1.0",
         "/share/vala",
         "*.la",
         "*.a"

--- a/org.gnome.Papers.json
+++ b/org.gnome.Papers.json
@@ -46,7 +46,12 @@
             "config-opts": [
                 "-Dothers=enabled",
                 "-Dgtk_doc=false",
-                "-Dman=false"
+                "-Dman=false",
+                "-Dinstalled_tests=false"
+            ],
+            "cleanup": [
+                "/share/thumbnailers",
+                "/bin"
             ],
             "sources": [
                 {


### PR DESCRIPTION
There is no runtime introspection anywhere, as everything is determined compile time. As such, these are never needed here.

Closes: https://github.com/flathub/org.gnome.Papers/issues/16