### PR TITLE
move help locale subdirectories to locale data dir for automatic locale-subsetting

### DIFF
--- a/org.gnome.Papers.json
+++ b/org.gnome.Papers.json
@@ -197,6 +197,9 @@
                         "cp cargo/config .cargo/"
                     ]
                 }
+            ],
+            "post-install": [
+                "for help_locale_dir in /app/share/help/??*; do mv $help_locale_dir /app/share/locale/${help_locale_dir##*/}/help; ln -s /app/share/locale/${help_locale_dir##*/}/help $help_locale_dir; done"
             ]
         }
     ]


### PR DESCRIPTION


This workaround enables us to reduce the installation size by only installing the required help page for the user's requested locale(s).

Link: https://github.com/flatpak/flatpak/issues/4450