### PR TITLE
remove unused dependency libgxps

### DIFF
--- a/org.gnome.Papers.json
+++ b/org.gnome.Papers.json
@@ -129,24 +129,6 @@
             ]
         },
         {
-            "name": "libgxps",
-            "buildsystem": "meson",
-            "config-opts": [
-                "-Denable-test=false",
-                "-Ddisable-introspection=true"
-            ],
-            "cleanup": [
-                "/bin"
-            ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://download.gnome.org/sources/libgxps/0.3/libgxps-0.3.2.tar.xz",
-                    "sha256": "6d27867256a35ccf9b69253eb2a88a32baca3b97d5f4ef7f82e3667fa435251c"
-                }
-            ]
-        },
-        {
             "name": "papers",
             "buildsystem": "meson",
             "config-opts": [


### PR DESCRIPTION
Papers no longer supports XPS.