### PR TITLE
Update Poppler to 26.05

### DIFF
--- a/org.gnome.Papers.json
+++ b/org.gnome.Papers.json
@@ -76,8 +76,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://poppler.freedesktop.org/poppler-26.04.0.tar.xz",
-                    "sha256": "b0955163114af96bc0106f68cb24daf973a629462453d8b82775f81b0d4e0693",
+                    "url": "https://poppler.freedesktop.org/poppler-26.05.0.tar.xz",
+                    "sha256": "6fef27ff04f37db43054c86bcdff6128c9fb1f6af4ef3c8b369a7e9abd68d0bb",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 3686,


### PR DESCRIPTION
there has been a regression in poppler 26.04 that prevents some PDF files to display: https://gitlab.freedesktop.org/poppler/poppler/-/work_items/1714

So I think it would make sense to update here. Thanks